### PR TITLE
[fix] runner: add padding string and adjust the logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 *.env
 *.zip
 *.log
+*.txt
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/test_shell/test_runner.cpp
+++ b/test_shell/test_runner.cpp
@@ -30,13 +30,12 @@ int TestRunner::getResultFromCommand(std::string& command) {
     std::thread dotter([&]() {
         while (!done) {
             std::cerr << '.' << std::flush;
-            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            std::this_thread::sleep_for(std::chrono::milliseconds(200));
         }
         });
 
     std::ostringstream hiddenBuf;
     auto* oldCout = std::cout.rdbuf(hiddenBuf.rdbuf());
-    auto* oldCerr = std::cerr.rdbuf(hiddenBuf.rdbuf());
 
     int getResult = testShell.runCommand(command);
 
@@ -44,7 +43,6 @@ int TestRunner::getResultFromCommand(std::string& command) {
     dotter.join();
 
     std::cout.rdbuf(oldCout);
-    std::cerr.rdbuf(oldCerr);
 
     return getResult;
 }
@@ -54,10 +52,10 @@ void TestRunner::runScript(std::ifstream& script) {
     while (std::getline(script, cmd)) {
         if (cmd.empty())
             continue;
+        std::cout << std::left << std::setw(30) << cmd;
+        std::cerr <<" RUN" << std::flush;
 
-        std::cerr << cmd << " RUN" << std::flush;
-
-        if (getResultFromCommand(cmd) == NEXT_EXIT) std::cerr << " Pass\n";
+        if (getResultFromCommand(cmd) != NEXT_EXIT) std::cerr << " Pass\n";
         else {
             std::cerr << " FAIL!\n";
             return;


### PR DESCRIPTION
﻿## #️⃣ Issue Assigner

#손신

## 📝 요약(Summary)

실제 Test Script가 PASS를 뱉었으나, runner 실행 시 FAIL을 띄우는 문제가 발생했습니다.
command가 success를 뱉었으나, if문의 설정이 반대로 되어있었습니다.
또한 스트링 양식에 패딩문자를 추가해 RUN 문자가 동일한 곳에서 시작할 수 있게 패치를 작성하였습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

성공 시 아래와 같이 로그가 나옵니다.
'''
C:\Users\User\source\repos\ssd\ssd>..\x64\Release\test_shell.exe ..\test_shell\shell_script.txt                         

1_FullWriteAndReadCompare      RUN................ Pass                                                                
2_PartialLBAWrite                         RUN....................... Pass                                                          
3_WriteReadAging                       RUN.................................................................... Pass             
4_EraseAndWriteAging                RUN. Pass                                                                                                                                                                                                        
'''
## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
