### PR TITLE
[fix] remove debug message and erase bugFix

### DIFF
--- a/ssd/buffer_manager.cpp
+++ b/ssd/buffer_manager.cpp
@@ -93,7 +93,6 @@ void BufferManager::addErase(int lba, int size) {
 	if (emptyIdx == ALL_BUFFER_USED)
 		flushAndReset();
 
-	std::cout << size << std::endl;
 	emptyIdx = optimizeWriteBuffer(lba, size);
 
 	std::string old_path = bufferDirectory + "/" + bufferEntries[emptyIdx].originalFilename;
@@ -198,18 +197,19 @@ bool BufferManager::updateEraseRange(BufferEntry& oldBuffer, const BufferEntry& 
 	int newEndIndex = newBuffer.lba + std::stoi(newBuffer.value) - 1;
 	int oldStartIndex = oldBuffer.lba;
 	int oldEndIndex = oldBuffer.lba + std::stoi(oldBuffer.value) - 1;
-
+	int updateLBA = oldBuffer.lba;
+	int updateValue = std::stoi(oldBuffer.value);
 	if (newStartIndex < oldStartIndex) {
-		oldBuffer.lba = newStartIndex;
-		int newValue = std::stoi(oldBuffer.value) + oldStartIndex - newStartIndex;
-		if (newValue > 10) return false;
-		oldBuffer.value = std::to_string(newValue);
+		updateLBA = newStartIndex;
+		updateValue = updateValue + oldStartIndex - newStartIndex;
+		if (updateValue > 10) return false;
 	}
 	if (newEndIndex > oldEndIndex) {
-		int newValue = std::stoi(oldBuffer.value) + newEndIndex - oldEndIndex;
-		if (newValue > 10) return false;
-		oldBuffer.value = std::to_string(newValue);
+		updateValue = updateValue + newEndIndex - oldEndIndex;
+		if (updateValue > 10) return false;
 	}
+	oldBuffer.lba = updateLBA;
+	oldBuffer.value = std::to_string(updateValue);
 	return true;
 }
 


### PR DESCRIPTION
﻿## #️⃣ Issue Assigner

#박종원

## 📝 요약(Summary)

erase 범위가 10이 넘어가지 않도록 체크하고 업데이트 하는 부분에 버그가 있어 수정하였습니다.
10이 넘어가지 않는 경우에 이전 buffer entry 의 내용을 업데이트 하지 않고 return 하여야 하는데, 내용을 업데이트하는 경우가 존재하였습니다.
실제로 buffer 파일명을 업데이트 하기 전에 return 하기 때문에 동작에는 문제가 없으나 코드 상으로 잘못 구현되어 있는 부분이기 때문에 수정해주었습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
